### PR TITLE
fix boolean flag comparison so large files don't consume memory

### DIFF
--- a/libs/core/csvConverter.js
+++ b/libs/core/csvConverter.js
@@ -7,7 +7,7 @@ var utils=require("util");
 
 //it is a bridge from csv component to our parsers
 function csvAdv(constructResult){
-    if (typeof constructResult !== false){
+    if (constructResult !== false){
         constructResult=true;
     }
     var instance= csv.apply(this);


### PR DESCRIPTION
This was changing constructResult to true when it was set to false and therefore consuming lots of memory on large files.
