### PR TITLE
Fix for exception when processing rows

### DIFF
--- a/libs/core/csvConverter.js
+++ b/libs/core/csvConverter.js
@@ -23,7 +23,7 @@ function csvAdv(constructResult){
             var resultRow={};
             that._rowProcess(row,index,resultRow);
             if (constructResult){
-                that.resultObject.csvRows.push(resultRow);    
+                that.resultObject.csvRows.push(resultRow);
             }
             instance.emit("record_parsed",resultRow,row,index);
         }
@@ -40,7 +40,7 @@ csvAdv.prototype._headRowProcess=function(headRow){
     this.parseRules=parserMgr.initParsers(headRow);
 }
 csvAdv.prototype._rowProcess=function(row,index,resultRow){
-    for (var i=0;i<row.length;i++){
+    for (var i=0;i<parseRules.length;i++){
         var item=row[i];
         var parser=this.parseRules[i];
         var head=this.headRow[i];


### PR DESCRIPTION
After running into a few exceptions when uploading gmail contact csvs - i dug a little deeper and noticed that in some instances when processing rows the parser array( parseRules) and the row array didn’t match up - In a lot of cases there was always one more row then parsers which caused an exception since the parser did not exist and the parse method could not be called - The fix I added was instead of iterating on the rows array - do it on the parsers - so that if the 2 arrays don’t match - then the service won’t just fail silently.
