### PR TITLE
fixed removal of delimiters in quoted element and premature trim

### DIFF
--- a/libs/core/init_onrecord.js
+++ b/libs/core/init_onrecord.js
@@ -15,14 +15,14 @@ module.exports = function() {
     var quoteBuff = "";
     for (var i = 0; i < rowArr.length; i++) {
       var ele = rowArr[i];
-      if (self.param.trim){
-        ele=ele.toString().trim();
-      }
       if (self._isToogleQuote(ele)) {
         if (inquote) {
           quoteBuff += delimiter;
           inquote = false;
           quoteBuff += ele.substr(0, ele.length - 1);
+          if (self.param.trim){
+            quoteBuff=quoteBuff.toString().trim();
+          }
           row.push(quoteBuff);
           quoteBuff = "";
         } else {
@@ -31,10 +31,13 @@ module.exports = function() {
         }
       } else {
         if (inquote) {
-          quoteBuff += ele;
+          quoteBuff += delimiter + ele;
         } else {
           if (ele.indexOf(quote) === 0 && ele[ele.length - 1] == quote) {
             ele = ele.substring(1, ele.length - 1);
+          }
+          if (self.param.trim){
+            ele=ele.toString().trim();
           }
           row.push(ele);
         }


### PR DESCRIPTION
When the elements are separated based on a delimiter and then joined again (if the element was originally quoted) the delimiter is not added back in. So for example `"Many types of citrus are available, including oranges, white grapefruit, tangelos, and lemons."` became `"notes":"Many types of citrus are availableincluding orangeswhite grapefruittangelos,and lemons."` in json. The trim, if set to true, was also done before the quoted elements were joined back together so the whitespacing ended up incorrect. This pull requests fixes these two minor issues.
