### PR TITLE
Supporting auto-detecting of CSV delimiter

### DIFF
--- a/libs/core/utils.js
+++ b/libs/core/utils.js
@@ -1,14 +1,26 @@
 /**
  */
+var CSV = require('csv-string');
 
 module.exports = {
+  getDelimiter: getDelimiter, // Handle auto delimiter: return explicitely specified delimiter or try auto detect
   rowSplit: rowSplit, //Split a csv row to an array based on delimiter and quote
   isToogleQuote: isToogleQuote, //returns if a segmenthas even number of quotes
   twoDoubleQuote: twoDoubleQuote //converts two double quotes to one
 }
 var cachedRegExp = {};
 
+function getDelimiter(rowStr, originalDelimiter) {
+  if (originalDelimiter === "auto") {
+    var delimiter = CSV.detect(rowStr);
+    return delimiter === null ? "," : delimiter;
+  } else {
+    return originalDelimiter;
+  }
+}
+
 function rowSplit(rowStr, delimiter, quote, trim) {
+  delimiter = getDelimiter(rowStr, delimiter);
   var rowArr = rowStr.split(delimiter);
   var row = [];
   var inquote = false;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "async": "^1.2.1"
+    "async": "^1.2.1",
+    "csv-string": "^2.3.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -142,7 +142,7 @@ var converter=new require("csvtojson").Converter({
 Following parameters are supported:
 
 * **constructResult**: true/false. Whether to construct final json object in memory which will be populated in "end_parsed" event. Set to false if deal with huge csv data. default: true.
-* **delimiter**: delimiter used for seperating columns. default: ","
+* **delimiter**: delimiter used for seperating columns. Use "auto" if delimiter is unknown in advance, in this case, delimiter will be auto-detected (by best attempt). default: ","
 * **quote**: If a column contains delimiter, it is able to use quote character to surround the column content. e.g. "hello, world" wont be split into two columns while parsing. default: " (double quote)
 * **trim**: Indicate if parser trim off spaces surrounding column content. e.g. "  content  " will be trimmed to "content". Default: true
 * **checkType**: This parameter turns on and off weather check field type. default is true. See [Field type](#field-type)

--- a/test/testDelimiter.js
+++ b/test/testDelimiter.js
@@ -1,0 +1,25 @@
+var Utils = require("../libs/core/utils.js");
+var assert = require("assert");
+
+describe("Test delimiters", function () {
+  it("should return the explicitly specified delimiter", function() {
+    delimiter = ';'
+    rowStr = 'a;b;c';
+    returnedDelimiter = Utils.getDelimiter(rowStr, delimiter);
+    assert(returnedDelimiter === delimiter);
+  });
+
+  it("should return the autodetected delimiter if 'auto' specified", function() {
+    delimiter = 'auto'
+    rowStr = 'a;b;c';
+    returnedDelimiter = Utils.getDelimiter(rowStr, delimiter);
+    assert(returnedDelimiter === ';');
+  });
+
+  it("should return the ',' delimiter if delimiter cannot be specified, in case of 'auto'", function() {
+    delimiter = 'auto'
+    rowStr = 'abc';
+    returnedDelimiter = Utils.getDelimiter(rowStr, delimiter);
+    assert(returnedDelimiter === ',');
+  });
+});


### PR DESCRIPTION
In some cases, especially when CSV is streamed from web, delimiter is unknown in advance. In this PR, you can specify 'auto' as delimiter. In this case, delimiter will be auto-detected line-by-line. If it cannot detect delimiter, it will try using the default (",").