### PR TITLE
Interpret item with preceding 0s as a string

### DIFF
--- a/libs/core/parser.js
+++ b/libs/core/parser.js
@@ -16,7 +16,7 @@ function Parser(name, regExp, parser, processSafe) {
     this.parse = parser;
   }
 }
-var numReg = /^([-+]?[1-9][0-9]*\.?)|^([-+]?0\.)[0-9]+([eE][-+]?[0-9]+)?$/;
+var numReg = /^(([-+]?[1-9][0-9]*\.?)|([-+]?0\.))[0-9]+([eE][-+]?[0-9]+)?$/;
 Parser.prototype.convertType = function(item) {
   var type=this.type;
   if (type === 'number') {

--- a/libs/core/parser.js
+++ b/libs/core/parser.js
@@ -16,7 +16,7 @@ function Parser(name, regExp, parser, processSafe) {
     this.parse = parser;
   }
 }
-var numReg = /^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$/;
+var numReg = /^([-+]?[1-9][0-9]*\.?)|^([-+]?0\.)[0-9]+([eE][-+]?[0-9]+)?$/;
 Parser.prototype.convertType = function(item) {
   var type=this.type;
   if (type === 'number') {


### PR DESCRIPTION
Excluding a 0 directly before a decimal

0.5      ->     number
00.5    ->     string
-0.5     ->     number
10.3    ->     number
010.3  ->     string
11       ->     number
011     ->     string