### PR TITLE
Output eol between ndjson lines

### DIFF
--- a/libs/core/Converter.js
+++ b/libs/core/Converter.js
@@ -183,16 +183,13 @@ Converter.prototype.flushBuffer = function() {
       resultJSONStr=JSON.stringify(resultRow);
     }
     this.emit("record_parsed", resultRow, row, index);
-    if (this.recordNum > 0) {
-      if (this.param.toArrayString) {
-        this.push(",");
-      }
-      this.push(eol);
+    if (this.param.toArrayString && this.recordNum > 0) {
+      this.push("," + eol);
     }
     if (this._options && this._options.objectMode){
       this.push(resultRow);
     }else{
-      this.push(resultJSONStr, "utf8");
+      this.push(resultJSONStr + eol, "utf8");
     }
     this.recordNum++;
   }

--- a/libs/core/Converter.js
+++ b/libs/core/Converter.js
@@ -183,8 +183,11 @@ Converter.prototype.flushBuffer = function() {
       resultJSONStr=JSON.stringify(resultRow);
     }
     this.emit("record_parsed", resultRow, row, index);
-    if (this.param.toArrayString && this.recordNum > 0) {
-      this.push("," + eol);
+    if (this.recordNum > 0) {
+      if (this.param.toArrayString) {
+        this.push(",");
+      }
+      this.push(eol);
     }
     if (this._options && this._options.objectMode){
       this.push(resultRow);


### PR DESCRIPTION
While trying to stream a large csv to ndjson, there aren't newlines between each line. Here is an example of the cli command that reproduces the issue:
```
cat large.csv | csvtojson --noheader=true --flatKeys=true --workerNum=8 --maxRowLength=0 --toArrayString=false --delimiter='|'
```

Let me know if there is a better way to handle this.