### PR TITLE
Added csv url example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,23 @@ csv()
 
 ```
 
+### From CSV Url
+
+```js
+const request=require('request')
+const csv=require('csvtojson')
+
+csv()
+.fromStream(request.get('http://mywebsite.com/mycsvfile.csv'))
+.on('csv',(csvRow)=>{
+	// csvRow is an array
+})
+.on('done',(error)=>{
+
+})
+
+```
+
 ### Convert to CSV row arrays with csv header row
 
 ```js


### PR DESCRIPTION
This took my quite some time to figure out, so i'm adding it to the docs
somehow the stream example wasn't clear enough because the old way of writing this (before 1.1.0) was:
```js
request.get(url).pipe(csv);
```