### PR TITLE
Detect EOL from file when not found in first chunk

### DIFF
--- a/libs/core/csvline.js
+++ b/libs/core/csvline.js
@@ -16,7 +16,7 @@ module.exports = function(lines, param) {
       csvLines.push(row.cols);
       left = "";
     } else {
-      left = line + getEol(line, param);
+      left = line + (getEol(line, param) || "\n"); // if unable to getEol from data, assume "\n"
     }
   }
   return {lines: csvLines, partial: left};

--- a/libs/core/getEol.js
+++ b/libs/core/getEol.js
@@ -6,7 +6,7 @@ module.exports = function(data, param) {
       if (data[i] === "\r") {
         if (data[i + 1] === "\n") {
           param.eol = "\r\n";
-        } else {
+        } else if (data[i + 1]) {
           param.eol = "\r";
         }
         return param.eol;
@@ -15,7 +15,6 @@ module.exports = function(data, param) {
         return param.eol;
       }
     }
-    param.eol = eol;
   }
   return param.eol;
 };

--- a/readme.md
+++ b/readme.md
@@ -270,7 +270,7 @@ Following parameters are supported:
 * **flatKeys**: Don't interpret dots (.) and square brackets in header fields as nested object or array identifiers at all (treat them like regular characters for JSON field identifiers). Default: false.
 * **maxRowLength**: the max character a csv row could have. 0 means infinite. If max number exceeded, parser will emit "error" of "row_exceed". if a possibly corrupted csv data provided, give it a number like 65535 so the parser wont consume memory. default: 0
 * **checkColumn**: whether check column number of a row is the same as headers. If column number mismatched headers number, an error of "mismatched_column" will be emitted.. default: false
-* **eol**: End of line character. If omitted, parser will attempt retrieve it from first chunk of CSV data. If no valid eol found, then operation system eol will be used.
+* **eol**: End of line character. If omitted, parser will attempt to retrieve it from the first chunks of CSV data.
 * **escape**: escape character used in quoted column. Default is double quote (") according to RFC4108. Change to back slash (\\) or other chars for your own case.
 * **includeColumns**: This parameter instructs the parser to include only those columns as specified by an array of column indexes or header names.  Example: [0,2,3,"name"] will parse and include only columns 0, 2, 3, and column with header "name" in the JSON output.
 * **ignoreColumns**: This parameter instructs the parser to ignore columns as specified by an array of column indexes or header names.  Example: [1,3,5,"title","age"] will ignore columns 1, 3, 5, title column and age column and will not return them in the JSON output.

--- a/test/data/dataNoTrimCRLF
+++ b/test/data/dataNoTrimCRLF
@@ -1,0 +1,3 @@
+name,age
+joe,20
+sam,30

--- a/test/testCSVConverter.js
+++ b/test/testCSVConverter.js
@@ -375,4 +375,38 @@ describe("CSV Converter", function () {
       done();
     });
   });
+
+  it("should detect eol correctly when first chunk is smaller than header row length", function (done) {
+    var testData = __dirname + "/data/dataNoTrimCRLF";
+    var rs = fs.createReadStream(testData, {highWaterMark: 3});
+
+    var st = rs.pipe(new Converter({
+      trim: false
+    }));
+    st.on("end_parsed", function (res) {
+      var j = res[0];
+
+      assert(res.length===2);
+      assert(j.name === "joe");
+      assert(j.age === "20");
+      done();
+    });
+  });
+
+  it("should detect eol correctly when first chunk ends in middle of CRLF line break", function (done) {
+    var testData = __dirname + "/data/dataNoTrimCRLF";
+    var rs = fs.createReadStream(testData, {highWaterMark: 9});
+
+    var st = rs.pipe(new Converter({
+      trim: false
+    }));
+    st.on("end_parsed", function (res) {
+      var j = res[0];
+
+      assert(res.length===2);
+      assert(j.name === "joe");
+      assert(j.age === "20");
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Currently, the README says "Parser will attempt retrieve it from first chunk of CSV data." This works if the first chunk is bigger than the header row. But if not, line endings are not detected. It would be much nicer if instead of looking at only the first chunk, we look at all chunks until we hit a line ending and then use that as the eol.

An additional improvement here is that if the first chunk ends in-between the "\r" and "\n" in a file with "\r\n" line endings, getEol will detect "\r" as eol without checking that the following character might be "\n". This PR takes care of that, as well.