### PR TITLE
Added 'header' event.  Emit the header values.

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
       "hireable": true
     }
   ],
-  "version": "1.1.7",
+  "version": "1.1.8",
   "keywords": [
     "csv",
     "csv parser",

--- a/readme.md
+++ b/readme.md
@@ -272,6 +272,22 @@ All parameters can be used in Command Line tool.
 
 `Converter` class defined a series of events.
 
+### header
+
+`header` event is emitted for each CSV file. It passes an array object which contains the names of the header row.
+
+```js
+const csv=require('csvtojson')
+csv()
+.on('header',(header)=>{
+	//header=> [header1, header2, header3]
+})
+```
+
+`header` is always an array of strings without types.
+
+`header` event will be emitted regardless of the `noHeaders` parameter setting.
+
 ### json
 
 `json` event is emitted for each parsed CSV line. It passes JSON object and the row number of the CSV line in its callback function.

--- a/test/testCSVConverter2.js
+++ b/test/testCSVConverter2.js
@@ -434,6 +434,10 @@ describe("CSV Converter", function () {
      ignoreColumns:[0]
     })
     .fromStream(rs)
+    .on("header", function(header) {
+      assert.equal(header.indexOf("TIMESTAMP"), -1);
+      assert.equal(header.indexOf("UPDATE"), 0);
+    })
     .on("csv", function(row, idx) {
       assert(idx >= 0);
       if (idx ===1){
@@ -455,6 +459,11 @@ describe("CSV Converter", function () {
      includeColumns:[0]
     })
     .fromStream(rs)
+    .on("header", function(header) {
+      assert.equal(header.indexOf("TIMESTAMP"), 0);
+      assert.equal(header.indexOf("UPDATE"), -1);
+      assert.equal(header.length, 1);
+    })
     .on("csv", function(row, idx) {
       assert(idx >= 0);
       assert.equal(row.length, 1);


### PR DESCRIPTION
Took a look at the code and found that slipping in the `header` event as described in #141 was pretty simple.

Also, updated the tests and the readme.

Others can use it [here](https://github.com/brucejo75/node-csvtojson) while waiting for @Keyang  to accept or properly integrate.