### PR TITLE
Fix Issue with Library Mutating Input Param Object.

### DIFF
--- a/libs/core/defParam.js
+++ b/libs/core/defParam.js
@@ -33,7 +33,11 @@ module.exports = function (params) {
   }
   for (var key in params) {
     if (params.hasOwnProperty(key)) {
-      _param[key] = params[key];
+      if (Array.isArray(params[key])) {
+        _param[key] = [].concat(params[key]);
+      } else {
+        _param[key] = params[key];
+      }
     }
   }
   if (_param.ignoreColumns.length > 0 && !numExp.test(_param.ignoreColumns.join(""))) {

--- a/test/testCSVConverter2.js
+++ b/test/testCSVConverter2.js
@@ -487,6 +487,66 @@ describe("CSV Converter", function () {
       done();
     });
   });
+
+  it("should allow headers and include columns to be given as reference to the same var", function(done) {
+    var rs = fs.createReadStream(__dirname + "/data/complexJSONCSV");
+    const headers = [
+      'first',
+      'second',
+      'third',
+    ];
+
+    const expected = [].concat(headers);
+
+    csv({
+      headers: headers,
+      includeColumns: headers,
+    })
+      .fromStream(rs)
+      .on("header", function(header) {
+        expected.forEach(function(value, index) {
+          assert.equal(header.indexOf(value), index);
+        });
+      })
+      .on("json", function(j, idx) {
+        assert(idx >= 0);
+        assert.equal(expected.length, Object.keys(j).length);
+        expected.forEach(function(attribute) {
+          assert(j.hasOwnProperty(attribute));
+        });
+      })
+      .on("end", function() {
+        expected.forEach(function(value, index) {
+          assert.equal(headers.indexOf(value), index);
+        });
+        done();
+      });
+  });
+
+  it("should leave provided params objects unmutated", function(done) {
+    var rs = fs.createReadStream(__dirname + "/data/complexJSONCSV");
+    const includeColumns = [
+      'fieldA.title',
+      'description',
+    ];
+
+    const expected = [].concat(includeColumns);
+
+    csv({
+      includeColumns: includeColumns,
+    })
+      .fromStream(rs)
+      .on("json", function(j, idx) {
+        assert(idx >= 0);
+      })
+      .on("end", function() {
+        expected.forEach(function (header, index) {
+          assert.equal(index, includeColumns.indexOf(header));
+        });
+        done();
+      });
+  });
+
   it ("should only call done once",function(done){
     var counter=0;
     csv()


### PR DESCRIPTION
This commit fixes an issue where the input params objects were being
mutated.

It seems quite unexpected that the provided input params would be
mutated by the stream.

This was causing issues when using a list of headers that is
a subset of the whole CSV column set as therefore desiring to also
apply the same header set to the includeColumns so that resulting
JSON object doesn't have extra properties; Field1, Field2... etc.