### PR TITLE
Add catch when params._headers is not array

### DIFF
--- a/libs/core/linesToJson.js
+++ b/libs/core/linesToJson.js
@@ -10,7 +10,7 @@ var numReg = /^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$/;
  */
 module.exports = function (lines, params, idx) {
   if (params._needParseJson) {
-    if (!params._headers) {
+    if (!params._headers || !Array.isArray(params._headers)) {
       params._headers = [];
     }
     if (!params.parseRules) {


### PR DESCRIPTION
This pull request is to avoid error that occurs when you pass header param which is not an array

```
csv({headers: 'header1'})

csvtojson/libs/core/parserMgr.js:56

row.forEach(function (columnTitle) {
      ^

TypeError: row.forEach is not a function
```
