### PR TITLE
Remove Multi CPU Core link from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,7 +200,6 @@ $ csvtojson
 * [Hook / Transform](#hook--transform)
 * [Nested JSON Structure](#nested-json-structure)
 * [Header Row](#header-row)
-* [Multi CPU Core Support(experimental) ](#multi-cpu-core-support)
 * [Column Parser](#column-parser)
 
 


### PR DESCRIPTION
The "Multi CPU Core Support" link in the README.md points to a section removed in commit [70db0d1](https://github.com/Keyang/node-csvtojson/commit/70db0d16bccaaaf98e04b4b05fe05e76abb59bc1#diff-0730bb7c2e8f9ea2438b52e419dd86c9).

Remove the dead link.