### PR TITLE
Fix parsing when quote is escaped inside quoted column containing delimiter (#318)

### DIFF
--- a/src/rowSplit.ts
+++ b/src/rowSplit.ts
@@ -75,9 +75,15 @@ export class RowSplit {
             continue;
           } else if (e.indexOf(quote) !== -1) {
             let count = 0;
+            let prev = "";
             for (const c of e) {
-              if (c === quote) {
+              // count quotes only if previous character is not escape char
+              if (c === quote && prev !== this.escape) {
                 count++;
+                prev = "";
+              } else {
+                // save previous char to temp variable
+                prev = c;
               }
             }
             if (count % 2 === 1) {

--- a/test/data/dataWithSlashEscapeAndDelimiterBetweenQuotes
+++ b/test/data/dataWithSlashEscapeAndDelimiterBetweenQuotes
@@ -1,0 +1,2 @@
+id,raw
+0,"\"hello,\"world\""

--- a/test/testCSVConverter2.ts
+++ b/test/testCSVConverter2.ts
@@ -294,7 +294,22 @@ describe("testCSVConverter2", function () {
     rs.pipe(test_converter);
   });
 
-  it("should output ndjson format", function (done) {
+  it("should process escape chars when delimiter is between escaped quotes", function(done) {
+    var test_converter = new Converter({
+      escape: "\\"
+    });
+
+    var testData =
+      __dirname + "/data/dataWithSlashEscapeAndDelimiterBetweenQuotes";
+    var rs = fs.createReadStream(testData);
+    test_converter.then(function(res) {
+      assert.equal(res[0].raw, '"hello,"world"');
+      done();
+    });
+    rs.pipe(test_converter);
+  });
+
+  it("should output ndjson format", function(done) {
     var conv = new Converter();
     conv.fromString("a,b,c\n1,2,3\n4,5,6")
       .on("data", function (d) {


### PR DESCRIPTION
Hi @Keyang,

As explained in https://github.com/Keyang/node-csvtojson/issues/318, parsing fails if escape character is specified (and different than `"`), and a delimiter is between escaped quotes.

A few examples (with option `escape='\'`):
```
id,raw
0,"hello,world"         // OK raw: hello,world
1,"hello,\"world"       // OK raw: hello,"world
2,"hello\",world"       // KO raw: hello\" field3: world
3,"\"hello,world\""     // KO raw: "\"hello" field3: world\"
4,"\"hello,\"world\""   // KO raw: "\hello field3: \"world\""
5,"\"hello\",world\""   // OK raw: "hello",world"
6,"\"hello\",\"world\"" // OK raw: "hello","world"
```

With this fix:
```
0,"hello,world"         // OK raw: hello,world
1,"hello,\"world"       // OK raw: hello,"world
2,"hello\",world"       // OK raw: hello",world
3,"\"hello,world\""     // OK raw: "hello,world"
4,"\"hello,\"world\""   // OK raw: "hello,"world"
5,"\"hello\",world\""   // OK raw: "hello",world"
6,"\"hello\",\"world\"" // OK raw: "hello","world"
```

Hope you will review this pull request, as it seems like you haven't maintained the repo since last year.
Great work, by the way.

Cheers,
Adrien.