### PR TITLE
fix unused variable prevent string enforcement

### DIFF
--- a/src/Converter.ts
+++ b/src/Converter.ts
@@ -59,7 +59,7 @@ export class Converter extends Transform implements PromiseLike<any[]> {
     return this;
   }
   fromString(csvString: string): Converter {
-    const csv = csvString.toString();
+    csvString = csvString.toString(); // enforce a string
     const read = new Readable();
     let idx = 0;
     read._read = function (size) {


### PR DESCRIPTION
There was the call `const csv = csvString.toString();` which enforces the input of `fromString()` to be a string. But the variable `csv` was never used which is why I got the error `csvString.substr is not a function` deep in a subdependency.

I changed the code to actually use the string enforcement in the later calls.

What do you think about adding a tslint to the CI to prevent this bugs in the future?