### PR TITLE
Added rowIndex to colParser function

### DIFF
--- a/src/Parameters.ts
+++ b/src/Parameters.ts
@@ -88,7 +88,7 @@ export interface CSVParseParam {
   needEmitAll: boolean;
 }
 
-export type CellParser = (item: string, head: string, resultRow: any, row: string[], columnIndex: number) => any;
+export type CellParser = (item: string, head: string, resultRow: any, row: string[], columnIndex: number, rowIndex: number) => any;
 
 export interface ColumnParam {
   flat?: boolean;

--- a/src/lineToJson.ts
+++ b/src/lineToJson.ts
@@ -20,14 +20,14 @@ export type JSONResult = {
   [key: string]: any
 }
 
-function processRow(row: string[], conv: Converter, index): JSONResult | null {
+function processRow(row: string[], conv: Converter, index: number): JSONResult | null {
 
   if (conv.parseParam.checkColumn && conv.parseRuntime.headers && row.length !== conv.parseRuntime.headers.length) {
     throw (CSVError.column_mismatched(conv.parseRuntime.parsedLineNumber + index))
   }
 
   const headRow = conv.parseRuntime.headers || [];
-  const resultRow = convertRowToJson(row, headRow, conv);
+  const resultRow = convertRowToJson(row, headRow, conv,index);
   if (resultRow) {
     return resultRow;
   } else {
@@ -35,7 +35,7 @@ function processRow(row: string[], conv: Converter, index): JSONResult | null {
   }
 }
 
-function convertRowToJson(row: string[], headRow: string[], conv: Converter): { [key: string]: any } | null {
+function convertRowToJson(row: string[], headRow: string[], conv: Converter, rowIndex: number): { [key: string]: any } | null {
   let hasValue = false;
   const resultRow = {};
   
@@ -53,7 +53,7 @@ function convertRowToJson(row: string[], headRow: string[], conv: Converter): { 
     }
     const convFunc = getConvFunc(head, i, conv);
     if (convFunc) {
-      const convRes = convFunc(item, head, resultRow, row, i);
+      const convRes = convFunc(item, head, resultRow, row, i, rowIndex);
       if (convRes !== undefined) {
         setPath(resultRow, head, convRes, conv,i);
       }

--- a/test/testCSVConverter3.ts
+++ b/test/testCSVConverter3.ts
@@ -27,32 +27,34 @@ describe("testCSVConverter3", function () {
     });
     rs.pipe(csvConverter);
   });
-  it("should setup customise type convert function", function (done) {
-    csv({
+
+  it("should setup customise type convert function", async function () {
+    const json = await csv({
       checkType: true,
       colParser: {
         "column1": "string",
-        "column5": function (item, head, resultRow, row, i) {
+        "column5": function (item, head, resultRow, row, i, rowIndex) {
           assert.equal(item, '{"hello":"world"}');
-          assert.equal(head, "column5"),
-            assert(resultRow);
+          assert.equal(head, "column5");
+          assert(resultRow);
           assert(row);
           assert.equal(i, 5);
+
+          // this assumes we are parsing a file with a single row
+          assert.equal(rowIndex, 0);
+          
           return "hello world";
         }
       }
     })
-      .fromFile(__dirname + "/data/dataWithType")
-      .subscribe(function (json) {
-        assert.equal(typeof json.column1, "string");
-        assert.equal(json.column5, "hello world");
-        assert.strictEqual(json["name#!"], false);
-        assert.strictEqual(json["column9"], true);
-      })
-      .on('done', function () {
-        done()
-      });
-  })
+      .fromFile(__dirname + "/data/dataWithType");
+
+    assert.equal(typeof json[0].column1, "string");
+    assert.equal(json[0].column5, "hello world");
+    assert.strictEqual(json[0]["name#!"], false);
+    assert.strictEqual(json[0]["column9"], true);
+  });
+
   it("should accept pipe as quote", function (done) {
     csv({
       quote: "|",


### PR DESCRIPTION
Adds another parameter to the custom colParser function callback
that exposes the row index being processed. Zero-based. Adds an
assert to an existing test to provide coverage.

The unit test for this was not executing correctly, so no assertions
would fail under any conditions. I refactored the test to use
async/await instead of done() and the test started working as
expected.

Issue #373