### PR TITLE
Update NPM ignore to reduce bundle size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,6 +15,9 @@ graph.png
 .project
 .settings
 .vscode
-docs
+docs/
 devops
-coverage
+coverage/
+.nyc_output/
+.coveralls.yml
+.ts-node


### PR DESCRIPTION
If using both a .gitignore and .npmignore, npm will favor the .npmignore
and will not reference the .gitignore. This commit copies over missing
entries from the .gitignore into the .npmignore.

Current bundle contains ~7MB in coverage/ - this was already
in the .npmignore though. I'm not sure what the release process looks
like, but it may require further investigation by the maintainers to
fully resolve #417, #387, and #393.