### PR TITLE
Fix bug where closing quote was not removed

### DIFF
--- a/src/rowSplit.test.ts
+++ b/src/rowSplit.test.ts
@@ -137,6 +137,37 @@ describe("RowSplit.parse function", function () {
     assert.equal(res.cells[0],'"Weight" (kg)');
     assert.equal(res.cells[1],'Error code');
     assert.equal(res.cells[2],'"Height" (m)');
-    
+  })
+  it("should remove closing quote when cell string is quoted ", () => {
+    // manually edited csv often are formatted to have commas like columns
+    // this trailing whitespace should be removed before the closing quote is removed
+    const data = '   "   Text with ws   "  ,   "Text, with, commas"  ,   "   Text, with, both   "   ,   No quotes   ';
+    const rowSplit = new RowSplit(new Converter({
+      noheader: true,
+	  trim: false
+    }));
+    const res = rowSplit.parse(data);
+    assert.equal(res.cells.length, 4);
+    assert(res.closed);
+    assert.equal(res.cells[0],'   Text with ws   ');
+    assert.equal(res.cells[1],'Text, with, commas');
+    assert.equal(res.cells[2],'   Text, with, both   ');
+    assert.equal(res.cells[3],'   No quotes   ');
+  })
+  it("should remove trailing whitespace (and the closing quote) when cell string is quoted ", () => {
+    // manually edited csv often are formatted to have commas like columns
+    // this trailing whitespace should be removed before the closing quote is removed
+    const data = '   "   Text with ws   "  ,   "   Text, with, commas"  ,   "   Text, with, both   "   ,   No quotes   ';
+    const rowSplit = new RowSplit(new Converter({
+      noheader: true,
+	  trim: true
+    }));
+    const res = rowSplit.parse(data);
+    assert.equal(res.cells.length, 4);
+    assert(res.closed);
+    assert.equal(res.cells[0],'Text with ws');
+    assert.equal(res.cells[1],'Text, with, commas');
+    assert.equal(res.cells[2],'Text, with, both');
+    assert.equal(res.cells[3],'No quotes');
   })
 });

--- a/src/rowSplit.ts
+++ b/src/rowSplit.ts
@@ -67,9 +67,16 @@ export class RowSplit {
           row.push("");
           continue;
         } else if (this.isQuoteOpen(e)) { //quote open
+          e = trimLeft(e);
           e = e.substr(1);
+          if (trim) {
+            e = trimLeft(e);
+          }
           if (this.isQuoteClose(e)) { //quote close
             e = e.substring(0, e.lastIndexOf(quote));
+            if (trim) {
+              e = trimRight(e);
+            }
             e = this.escapeQuote(e);
             row.push(e);
             continue;
@@ -113,7 +120,7 @@ export class RowSplit {
       } else { //previous quote not closed
         if (this.isQuoteClose(e)) { //close double quote
           inquote = false;
-          e = e.substr(0, len - 1);
+          e = e.substring(0, e.lastIndexOf(quote));
           quoteBuff += delimiter + e;
           quoteBuff = this.escapeQuote(quoteBuff);
           if (trim) {
@@ -156,6 +163,7 @@ export class RowSplit {
   private isQuoteOpen(str: string): boolean {
     const quote = this.quote;
     const escape = this.escape;
+    str = trimLeft(str);
     return str[0] === quote && (
       str[1] !== quote ||
       str[1] === escape && (str[2] === quote || str.length === 2));
@@ -163,9 +171,7 @@ export class RowSplit {
   private isQuoteClose(str: string): boolean {
     const quote = this.quote;
     const escape = this.escape;
-    if (this.conv.parseParam.trim) {
-      str = trimRight(str);
-    }
+    str = trimRight(str);
     let count = 0;
     let idx = str.length - 1;
     while (str[idx] === quote || str[idx] === escape) {


### PR DESCRIPTION

I have seen many (manually edited) csv files in the wild that are formatted to visually have commas like columns. Example:

```
title ,description                                 ,number value,    more text,number 2
line 1,"short, precise"                            ,5           ,    sometimes,1
line 2,"a long, long description"                  ,6           ,         even,2
line 3,"an even longer description with many words",5           ,right-aligned,3
line 4,         "     and crazy stuff     "        ,5           ,      columns,3
```
The current implementation has some errors with those lines.

This closing quote and the whitespace is not removed (only the last space to be precise):
```
line 1,"short, precise"                            ,5           ,    sometimes,1
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This whitespace is not removed even if option trim is enabled (neither is the closing quote)
```
line 4,         "     and crazy stuff     "        ,5           ,      columns,3
                 ^^^^^               ^^^^^
```

The pull requests fixes those issues